### PR TITLE
:bug: fix: ensure rewarded ad modal closes after reward or close event

### DIFF
--- a/src/components/Ads/AdRewardFullScreeen.tsx
+++ b/src/components/Ads/AdRewardFullScreeen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 
 type Props = {
   isOpen: boolean;
-  onClose: () => void;
+  onClose: (isError: boolean) => void;
   onReward: (payload: googletag.RewardedPayload) => void;
 };
 
@@ -25,6 +25,7 @@ declare global {
 export default function AdRewardedFullScreen({ isOpen, onClose, onReward }: Props) {
   
   const slotRef = useRef<googletag.Slot | null>(null);
+  const closedRef = useRef(false);
   
   useEffect(() => {
     console.log("🔍 AdRewardedFullScreen useEffect triggered, isOpen:", isOpen);
@@ -75,7 +76,7 @@ export default function AdRewardedFullScreen({ isOpen, onClose, onReward }: Prop
 
         if (!rewardedSlot) {
           console.error("❌ Rewarded ad não suportado ou erro na definição do slot");
-          onClose();
+          onClose(true);
           return;
         }
 
@@ -93,11 +94,18 @@ export default function AdRewardedFullScreen({ isOpen, onClose, onReward }: Prop
         window.googletag.pubads().addEventListener("rewardedSlotGranted", (event: any) => {
           console.log("🎉 Recompensa concedida:", event.payload);
           onReward(event.payload);
+          if (!closedRef.current) {
+            closedRef.current = true;
+            onClose(false);
+          }
         });
 
         window.googletag.pubads().addEventListener("rewardedSlotClosed", () => {
           console.log("🛑 Anúncio fechado.");
-          onClose(); // ✅ FECHA AUTOMATICAMENTE
+          if (!closedRef.current) {
+            closedRef.current = true;
+            onClose(false);
+          }
         });
 
         console.log("🚀 Habilitando serviços e exibindo anúncio...");
@@ -109,7 +117,7 @@ export default function AdRewardedFullScreen({ isOpen, onClose, onReward }: Prop
     // Espera o script GPT carregar
     console.log("⏳ Aguardando API GPT ficar pronta...");
     let attempts = 0;
-    const maxAttempts = 30; // 5 segundos máximo
+    const maxAttempts = 30; // 3 segundos máximo
     
     const interval = setInterval(() => {
       attempts++;
@@ -120,9 +128,9 @@ export default function AdRewardedFullScreen({ isOpen, onClose, onReward }: Prop
         clearInterval(interval);
         initRewardedAd();
       } else if (attempts >= maxAttempts) {
-        console.error("❌ Timeout: API GPT não ficou pronta em 5 segundos");
+        console.error("❌ Timeout: API GPT não ficou pronta em 3 segundos");
         clearInterval(interval);
-        onClose();
+        onClose(true);
       }
     }, 100);
 

--- a/src/pages/room/store/index.jsx
+++ b/src/pages/room/store/index.jsx
@@ -68,6 +68,15 @@ export default function Store({ initialProducts, initialCouponCode }) {
     }
   };
 
+  const handleClose = (errorOccurred = false) => {
+    setOpen(false);
+    if (errorOccurred) {
+      console.log("[AdReward] Ocorreu um erro ao exibir o anúncio recompensado.");
+    } else {
+      console.log("[AdReward] Modal fechado normalmente.");
+    }
+  };
+
   useEffect(() => {
     if (couponCode) {
       validateCoupon(couponCode);
@@ -170,14 +179,8 @@ export default function Store({ initialProducts, initialCouponCode }) {
 
                 <AdRewardFullScreeen
                   isOpen={open}
-                  onClose={() => {
-                    console.log("🚪 Modal fechado");
-                    setOpen(false);
-                  }}
-                  onReward={() => {
-                    console.log("🎁 Recompensa recebida, chamando handleReward...");
-                    handleReward();
-                  }}                
+                  onClose={handleClose}
+                  onReward={handleReward}
                 />
               </Card>
             </div>


### PR DESCRIPTION
 ## :rocket: Feature: Rewarded Ads Modal Fix & Improvements

   ### :bug: Bug Fixes
   - :bug: **fix:** The rewarded ad modal now closes immediately after the user receives the reward or closes the ad, preventing video loops or unwanted retries.

   ### :sparkles: Features & Improvements
   - :sparkles: **feat:** Improved event handling for rewarded ads, ensuring a single close action and a better user experience.
   - :recycle: **refactor:** Cleaned up modal control logic, removed all retry logic, and improved code readability.

   ### :memo: Notes
   - :lock: No secrets or sensitive data in this branch/history.
   - :white_check_mark: All `_disabled` API files are identical to `main`.
   - :eyes: Ready for review and merge!
